### PR TITLE
Handle dropped tokens with attention masks

### DIFF
--- a/src/dataset/stage1_dataset.py
+++ b/src/dataset/stage1_dataset.py
@@ -17,13 +17,20 @@ def PriorCollate_fn(batch):
     clip_cloth_imgs = torch.stack([item["clip_cloth_img"] for item in batch])
     clip_warp_mask_imgs = torch.stack([item["clip_warp_mask_img"] for item in batch])
     clip_image_imgs = torch.stack([item["clip_image_img"] for item in batch])
+
+    agn_dropped = torch.tensor([item["agnostic_dropped"] for item in batch], dtype=torch.bool)
+    cloth_dropped = torch.tensor([item["cloth_dropped"] for item in batch], dtype=torch.bool)
+    img_dropped = torch.tensor([item["image_dropped"] for item in batch], dtype=torch.bool)
     
     return {
-            "clip_agnostic_img": clip_agnostic_imgs,
-            "clip_cloth_img": clip_cloth_imgs,
-            "clip_warp_mask_img": clip_warp_mask_imgs,
-            "clip_image_img": clip_image_imgs,
-        }
+        "clip_agnostic_img": clip_agnostic_imgs,
+        "clip_cloth_img": clip_cloth_imgs,
+        "clip_warp_mask_img": clip_warp_mask_imgs,
+        "clip_image_img": clip_image_imgs,
+        "agnostic_dropped": agn_dropped,
+        "cloth_dropped": cloth_dropped,
+        "image_dropped": img_dropped,
+    }
 
 
 class PriorImageDataset(Dataset):
@@ -115,20 +122,30 @@ class PriorImageDataset(Dataset):
         # 6. 随机丢弃
         #    根据你的需求，这里保留最初的逻辑
         # ---------------------------
+        agn_dropped = False
+        cloth_dropped = False
+        img_dropped = False
+
         if random.random() < self.s_img_drop_rate:
             clip_agnostic_img = torch.zeros_like(clip_agnostic_img)
+            agn_dropped = True
         if random.random() < self.s_pose_drop_rate:
             clip_cloth_img = torch.zeros_like(clip_cloth_img)
+            cloth_dropped = True
         if random.random() < self.t_img_drop_rate:
             clip_warp_mask_img = torch.zeros_like(clip_warp_mask_img)
         if random.random() < self.t_pose_drop_rate:
             clip_image_img = torch.zeros_like(clip_image_img)
+            img_dropped = True
 
         return {
             "clip_agnostic_img": clip_agnostic_img,
             "clip_cloth_img": clip_cloth_img,
             "clip_warp_mask_img": clip_warp_mask_img,
             "clip_image_img": clip_image_img,
+            "agnostic_dropped": agn_dropped,
+            "cloth_dropped": cloth_dropped,
+            "image_dropped": img_dropped,
         }
 
         # 

--- a/stage1_train_prior_model.py
+++ b/stage1_train_prior_model.py
@@ -221,6 +221,9 @@ def main():
                 tgt   = image_encoder(batch["clip_warp_mask_img"].to(accelerator.device, dtype=dtype)).image_embeds
 
             attn_mask = torch.ones((cloth.shape[0], 4), dtype=torch.bool, device=cloth.device)
+            attn_mask[:, 0] = ~batch["agnostic_dropped"].to(attn_mask.device)
+            attn_mask[:, 1] = ~batch["image_dropped"].to(attn_mask.device)
+            attn_mask[:, 2] = ~batch["cloth_dropped"].to(attn_mask.device)
             with accelerator.accumulate(prior):
                 pred = prior(proj_embedding=cloth, encoder_hidden_states=agn, encoder_hidden_states1=img, attention_mask=attn_mask).predicted_image_embedding
                 loss = F.mse_loss(pred.float(), tgt.float(), reduction="mean")


### PR DESCRIPTION
## Summary
- track dropped images in `PriorImageDataset`
- expose dropout flags via `PriorCollate_fn`
- use dropout flags to build the attention mask in training

## Testing
- `python -m py_compile src/dataset/stage1_dataset.py stage1_train_prior_model.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_686bc8f1cad88325a265989137202c0a